### PR TITLE
DEV: Ignore MATLAB autosave and mex files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# MATLAB #
+##########
+# Editor autosave files
+*~
+*.asv
+# Compiled MEX binaries (all platforms)
+*.mex*
+
 # Compiled source #
 ###################
 *.com


### PR DESCRIPTION
Adds MATLAB specific extensions to .gitignore.
