### PR TITLE
BUG: Disconnect outlinebounds on both ends

### DIFF
--- a/boundedline/outlinebounds.m
+++ b/boundedline/outlinebounds.m
@@ -27,6 +27,12 @@ for il = 1:numel(hp)
     ax = ancestor(hl(il), 'axes');
     
     nline = size(xy{1},2);
+    if mod(size(xy{1}, 1), 2) == 0
+        % Insert a NaN between upper and lower lines, so they're disconnected
+        L = size(xy{1}, 1) / 2;
+        xy{1} = [xy{1}(1:L, :); nan(1, nline); xy{1}(L+1:end, :)];
+        xy{2} = [xy{2}(1:L, :); nan(1, nline); xy{2}(L+1:end, :)];
+    end
     if nline > 1
         xy{1} = reshape([xy{1}; nan(1,nline)], [], 1);
         xy{2} = reshape([xy{2}; nan(1,nline)], [], 1);


### PR DESCRIPTION
Previous behavior was to have the lower and upper bound lines
drawn together, in one fully connected line. This lead to a line
connecting the lower and upper bound lines at one edge of the plot
(the +ve end).

In this bug-fix, the two lines are still plotted at once as a single
object, but are disconnected by including a NaN between the lower
and upper line segments.
