### PR TITLE
Fix for `outlinebounds(...)` to return a `line` objects.

### DIFF
--- a/boundedline/outlinebounds.m
+++ b/boundedline/outlinebounds.m
@@ -20,7 +20,7 @@ function hnew = outlinebounds(hl, hp)
 % Copyright 2012 Kelly Kearney
 
 
-hnew = zeros(size(hl));
+hnew = gobjects(size(hl));
 for il = 1:numel(hp)
     col = get(hl(il), 'color');
     xy = get(hp(il), {'xdata','ydata'});


### PR DESCRIPTION
Changes initialisation of return object from an array of zeroes to an array of graphics objects, to return `line` objects.

This fixes an issue whereby `hnew = outlinebounds(x, y, err)` (where x, y, err are all arrays of scalars) would not return a `line` object.

Details:
- Using MATLAB version:
```plaintext
-----------------------------------------------------------------------------------------------------------------------
MATLAB Version: 9.12.0.2039608 (R2022a) Update 5
Operating System: Linux 6.0.12-76060006-generic #202212290932~1671652965~22.04~452ea9d SMP PREEMPT_DYNAMIC Wed D x86_64
Java Version: Java 1.8.0_202-b08 with Oracle Corporation Java HotSpot(TM) 64-Bit Server VM mixed mode
-----------------------------------------------------------------------------------------------------------------------
MATLAB                                                Version 9.12        (R2022a)
Parallel Computing Toolbox                            Version 7.6         (R2022a)
```